### PR TITLE
Update Doctrine column template

### DIFF
--- a/templates/knp_symfony.xml
+++ b/templates/knp_symfony.xml
@@ -122,9 +122,11 @@
       <option name="PHP" value="true" />
     </context>
   </template>
-  <template name="doctrinecolumn" value="/**&#10; * @ORM\Column(type=&quot;$TYPE$&quot;)&#10; */&#10;private $$$PROPERTYNAME$;" description="Adds a property with @ORM annotations" toReformat="false" toShortenFQNames="true">
+  <template name="doctrinecolumn" value="/**&#10; * @var $PHPTYPE$&#10; *&#10; * @ORM\Column(name=&quot;$FIELDNAME$&quot;, type=&quot;$TYPE$&quot;)&#10; */&#10;private $$$PROPERTYNAME$;" description="Adds a property with @ORM annotations" toReformat="true" toShortenFQNames="true">
     <variable name="PROPERTYNAME" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="FIELDNAME" expression="snakeCase(PROPERTYNAME)" defaultValue="" alwaysStopAt="true" />
     <variable name="TYPE" expression="" defaultValue="" alwaysStopAt="true" />
+    <variable name="PHPTYPE" expression="snakeCase(TYPE)" defaultValue="" alwaysStopAt="true" />
     <context>
       <option name="PHP" value="true" />
     </context>


### PR DESCRIPTION
Here's the new template:

```php
/**
 * @var $PHPTYPE$
 *
 * @ORM\Column(name="$FIELDNAME$", type="$TYPE$")
 */
private $$$PROPERTYNAME$;
```

And the variables configuration:
![image](https://user-images.githubusercontent.com/3369266/43423684-5454ef1e-944d-11e8-8ad2-4e14966e1711.png)

IMO this is much better for DX to explicitly set the column name, and the PHP type is not always set in the constructor so it's useful too when one wants to generate getters & setters right away 😄 